### PR TITLE
Added support to hide chat if you click on a message already active

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -5,12 +5,23 @@ var remoteWindowURL = "https://chat.aaronpk.tv/overlay/";
 var remoteServerURL = remoteWindowURL + "pub";
 var version = "0.3.0";
 var config = {};
+var lastId = "";
 
 $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-live-chat-paid-message-renderer,yt-live-chat-membership-item-renderer,yt-live-chat-paid-sticker-renderer", function () {
 
   // Don't show deleted messages
   if($(this)[0].hasAttribute("is-deleted")) {
     console.log("Not showing deleted message");
+    return;
+  }
+
+  if (sessionID && this.id === lastId) {
+    lastId = "";
+    var remote = {
+      version: version,
+      command: "hide"
+    };
+    $.post(remoteServerURL+"?id="+sessionID, JSON.stringify(remote));
     return;
   }
 
@@ -32,6 +43,7 @@ $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-liv
    */
 
   var data = {};
+
 
   data.message = $(this).find("#message").html();
 
@@ -73,14 +85,15 @@ $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-liv
     data.textColor = "color: #111;";
   }
 
-  if(sessionID) {
 
+  if(sessionID) {
     var remote = {
       version: version,
       command: "show",
       data: data,
       config: config
     }
+    lastId = this.id;
     $.post(remoteServerURL+"?id="+sessionID, JSON.stringify(remote));
 
   }


### PR DESCRIPTION
Hey Aaron, big fan. Would love to get this feature into production plugin.

### How to Test
1. Using published plugin, select a chat twice.
1. Note the message appears, then reanimates and displays again.
1. Load this branch using unpacked extension.
1. Select a chat message.
1. Select that same message again, not it closes.
1. Select a different message, not it display.
1. Select yet another message


### Load Unpacked extension
chrome://extensions/
Then choose "Load unpacked", and navigate to this root folder of this branch.