### PR TITLE
Fix issue #43 and add UI for Persistent Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ You can open the URL on your computer too if you want to full screen it on a sec
 
 ### Persistent Links
 
-There is now an option for "Persistent Session ID" to enable a persistent link for your stream so that you don't have to re-add the browser source every time. Here is how to use it it.
+There is now an option for "Persistent Session ID" to enable a persistent link for your stream so that you don't have to re-add the browser source every time. Here is how to use it.
 
-In the options form, check "PersistentSession ID" which will show a text box with a randomly generated Session ID. This Session ID will be used for a
+In the options form, check "Persistent Session ID" which will show a text box with a randomly generated Session ID. This Session ID will be used for a
 ll you future chats. You can also changle the Session ID inthat field if you want to reuse one that you already saved in a browser source.
 
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,10 @@ You can open the URL on your computer too if you want to full screen it on a sec
 
 ### Persistent Links
 
-While there is no UI for this currently, if you would like to create a persistent link for your stream so that you don't have to re-add the browser source every time, here is how to do it.
+There is now an option for "Persistent Session ID" to enable a persistent link for your stream so that you don't have to re-add the browser source every time. Here is how to use it it.
 
-* Click "Get Overlay" on a livestream and grab the URL from the field that appears, which should look like `https://chat.aaronpk.tv/overlay/#3gADdqH3NS`
-* Notice that your YouTube popout chat address bar has changed to include the same fragment, e.g. `#3gADdqH3NS`
-* In the future, add that fragment part to your YouTube popout chat window and reload the page
-* Your YouTube chat window will send to the matching `chat.aaronpk.tv` URL that has the same fragment
+In the options form, check "PersistentSession ID" which will show a text box with a randomly generated Session ID. This Session ID will be used for a
+ll you future chats. You can also changle the Session ID inthat field if you want to reuse one that you already saved in a browser source.
 
 
 ## See this in action!

--- a/settings/options.html
+++ b/settings/options.html
@@ -33,6 +33,12 @@
       border: 0;
       border-top: 1px #ccc solid;
     }
+    #toggle-persistent {
+       display: none;
+    }
+    #persistent-session-id[type=checkbox]:checked~#toggle-persistent {
+       display: block;
+    }
   </style>
 </head>
 <body>
@@ -108,6 +114,14 @@
       <div class="setting">
         <label>Remote Server URL</label>
         <input type="url" class="text" id="server-url">
+      </div>
+      <div class="setting">
+        <input type="checkbox" class="checkbox" id="persistent-session-id">
+        <label for "persistent-session-id">Persistent Session ID</label>
+        <div class="setting" id="toggle-persistent">
+          <label>Session ID (up to 10 alphanumeric characters)</label>
+          <input type="text" pattern="[a-zA-Z0-9]+" maxlength="10" class="text" id="session-id">
+        </div>
       </div>
     </div>
     <div class="section">

--- a/settings/options.js
+++ b/settings/options.js
@@ -8,7 +8,6 @@ function generateSessionID(){
 };
 
 function toggleSessionID() {
-  alert("Hi");
   if (this.checked) {
      console.log("Checked");
      document.querySelector("#session-id").value = generateSessionID();

--- a/settings/options.js
+++ b/settings/options.js
@@ -1,3 +1,24 @@
+function generateSessionID(){
+  var text = "";
+  var chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789";
+  for (var i = 0; i < 10; i++){
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+};
+
+function toggleSessionID() {
+  alert("Hi");
+  if (this.checked) {
+     console.log("Checked");
+     document.querySelector("#session-id").value = generateSessionID();
+  } else {
+     console.log("Unchecked");
+     document.querySelector("#session-id").value = nil;
+  }
+}
+
+
 function saveOptions(e) {
   e.preventDefault();
   chrome.storage.sync.set({
@@ -17,13 +38,15 @@ function saveOptions(e) {
     showOnlyFirstName: document.querySelector("#firstname").checked,
     autoHideSeconds: document.querySelector("#auto-hide-seconds").value,
     popoutURL: document.querySelector("#popout-url").value,
-    serverURL: document.querySelector("#server-url").value
+    serverURL: document.querySelector("#server-url").value,
+    persistentSessionID: document.querySelector("#persistent-session-id").checked,
+    sessionID: document.querySelector("#session-id").value
   });
 }
 
 function restoreOptions() {
 
-  var properties = ["color","scale","commentBottom","commentHeight","sizeOffset","authorBackgroundColor","authorAvatarBorderColor","authorColor","commentBackgroundColor","commentColor","fontFamily","showOnlyFirstName","highlightWords","popoutURL","autoHideSeconds","authorAvatarOverlayOpacity"];
+  var properties = ["color","scale","commentBottom","commentHeight","sizeOffset","authorBackgroundColor","authorAvatarBorderColor","authorColor","commentBackgroundColor","commentColor","fontFamily","showOnlyFirstName","highlightWords","popoutURL","serverURL","autoHideSeconds","authorAvatarOverlayOpacity","persistentSessionID","sessionID"];
   chrome.storage.sync.get(properties, function(result){
     document.querySelector("#color").value = result.color || "#000";
     document.querySelector("#scale").value = result.scale || "1.0";
@@ -39,11 +62,14 @@ function restoreOptions() {
     document.querySelector("#font-family").value = result.fontFamily || "Avenir Next, Helvetica, Geneva, Verdana, Arial, sans-serif";
     document.querySelector("#firstname").checked = result.showOnlyFirstName || false;
     document.querySelector("#auto-hide-seconds").value = result.autoHideSeconds || 0;
-    document.querySelector("#highlight-words").value = result.highlightWords.join(", ") || "question";
+    document.querySelector("#highlight-words").value = result.highlightWords.join(", ") || "q, question";
     document.querySelector("#popout-url").value = result.popoutURL || "https://chat.aaronpk.tv/overlay/";
     document.querySelector("#server-url").value = result.serverURL || "https://chat.aaronpk.tv/overlay/pub";
+    document.querySelector("#persistent-session-id").checked = result.persistentSessionID || false;
+    document.querySelector("#session-id").value = result.sessionID || nil;
   });
 
+  document.querySelector("#persistent-session-id").addEventListener("change", toggleSessionID);
 }
 
 document.addEventListener("DOMContentLoaded", restoreOptions);

--- a/settings/options.js
+++ b/settings/options.js
@@ -9,7 +9,6 @@ function generateSessionID(){
 
 function toggleSessionID() {
   if (this.checked) {
-     console.log("Checked");
      document.querySelector("#session-id").value = generateSessionID();
   } else {
      console.log("Unchecked");

--- a/settings/options.js
+++ b/settings/options.js
@@ -63,7 +63,7 @@ function restoreOptions() {
     document.querySelector("#popout-url").value = result.popoutURL || "https://chat.aaronpk.tv/overlay/";
     document.querySelector("#server-url").value = result.serverURL || "https://chat.aaronpk.tv/overlay/pub";
     document.querySelector("#persistent-session-id").checked = result.persistentSessionID || false;
-    document.querySelector("#session-id").value = result.sessionID || nil;
+    document.querySelector("#session-id").value = result.sessionID || "";
   });
 
   document.querySelector("#persistent-session-id").addEventListener("change", toggleSessionID);

--- a/settings/options.js
+++ b/settings/options.js
@@ -11,7 +11,6 @@ function toggleSessionID() {
   if (this.checked) {
      document.querySelector("#session-id").value = generateSessionID();
   } else {
-     console.log("Unchecked");
      document.querySelector("#session-id").value = nil;
   }
 }

--- a/settings/options.js
+++ b/settings/options.js
@@ -11,7 +11,7 @@ function toggleSessionID() {
   if (this.checked) {
      document.querySelector("#session-id").value = generateSessionID();
   } else {
-     document.querySelector("#session-id").value = nil;
+     document.querySelector("#session-id").value = "";
   }
 }
 

--- a/youtube.js
+++ b/youtube.js
@@ -184,7 +184,6 @@ function hideActiveChat() {
     var remote = {
       version: version,
       command: "hide",
-      html: '',
       config: config,
       v: videoID
     };

--- a/youtube.js
+++ b/youtube.js
@@ -183,7 +183,7 @@ function hideActiveChat() {
   if(sessionID) {
     var remote = {
       version: version,
-      command: "show",
+      command: "hide",
       html: '',
       config: config,
       v: videoID

--- a/youtube.js
+++ b/youtube.js
@@ -179,10 +179,13 @@ $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-liv
 });
 
 function hideActiveChat() {
+  var html = '<div class="hl-c-cont fadeout"></div>';
   if(sessionID) {
     var remote = {
       version: version,
-      command: "hide",
+      command: "show",
+      html: '',
+      config: config,
       v: videoID
     };
     $.post(remoteServerURL+"?v="+videoID+"&id="+sessionID, JSON.stringify(remote));
@@ -203,7 +206,7 @@ $("yt-live-chat-app").before( '<highlight-chat></highlight-chat><button class="b
 $("body").addClass("inline-chat");
 
 // Restore settings
-var configProperties = ["color","scale","sizeOffset","commentBottom","commentHeight","authorBackgroundColor","authorAvatarBorderColor","authorColor","commentBackgroundColor","commentColor","fontFamily","showOnlyFirstName","highlightWords","popoutURL","autoHideSeconds","authorAvatarOverlayOpacity"];
+var configProperties = ["color","scale","sizeOffset","commentBottom","commentHeight","authorBackgroundColor","authorAvatarBorderColor","authorColor","commentBackgroundColor","commentColor","fontFamily","showOnlyFirstName","highlightWords","popoutURL","serverURL","autoHideSeconds","authorAvatarOverlayOpacity","persistentSessionID","sessionID"];
 chrome.storage.sync.get(configProperties, function(item){
   var color = "#000";
   if(item.color) {
@@ -255,6 +258,9 @@ chrome.storage.sync.get(configProperties, function(item){
   }
   if(item.serverURL) {
     remoteServerURL = item.serverURL;
+  }
+  if(item.persistentSessionID && item.sessionID) {
+    sessionID = item.sessionID;
   }
 
   config = item;

--- a/youtube.js
+++ b/youtube.js
@@ -179,7 +179,6 @@ $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-liv
 });
 
 function hideActiveChat() {
-  var html = '<div class="hl-c-cont fadeout"></div>';
   if(sessionID) {
     var remote = {
       version: version,


### PR DESCRIPTION
In this pull request, issue #43 is fixed, plus I added a UI and supporting code implement persistent links. I also update the "Persistent Links" section of the README.md file.

When "Persistent Session ID" is checked in the options form, a random Session ID is generated. This Session ID will be save and reused until the option is unchecked. The SessionID can also be manually overwritten by the user.

There is one other code change I made and is slightly modified what happens when the user clicks the "CLEAR" button.
 Without this change, when starting a new stream using the chat overlay it is necessary to click on a chat message in the pop-out window, then click "CLEAR" in order to prime the overlay with the correct background color and styles. I changed the function so that clicking "CLEAR" is all that is need to prime the overlay window.

Thanks, Aaron, for this awesome Chrome extension!