### PR TITLE
Fix author image rezising logic and a small typo

### DIFF
--- a/youtube.js
+++ b/youtube.js
@@ -44,15 +44,23 @@ $("body").unbind("click").on("click", "yt-live-chat-text-message-renderer,yt-liv
   if(showOnlyFirstName) {
     data.authorname = data.authorname.replace(/ [^ ]+$/, '');
   }
-  data.authorimg = $(this).find("#img").attr('src');
-  data.authorimg = data.authorimg.replace("32", "128");
+  data.authorimg = $(this).find("#img").attr("src");
+  // Replace the 32px and 64px avatar with a 128px avatar but keep the identifier identical before the first '='
+  const equalIndex = data.authorimg.indexOf("=");
+  if (equalIndex !== -1) {
+    let part1 = data.authorimg.slice(0, equalIndex);
+    let part2 = data.authorimg.slice(equalIndex);
+    part2 = part2.replace("32", "128").replace("64", "128");
+
+    data.authorimg = part1 + part2;
+  }
 
   data.message = $(this).find("#message").html();
 
   data.sticker = $(this).find(".yt-live-chat-paid-sticker-renderer #sticker #img").attr("src");
 
 
-  // Donation amounts for stickers use a differnet id than regular superchats
+  // Donation amounts for stickers use a different id than regular superchats
   if(data.sticker) {
     data.donation = $(this).find("#purchase-amount-chip").html();
   } else {


### PR DESCRIPTION
Hey 👋🏻 

I ran into a problem while watching a stream that uses this extension. When my comments are highlighted my profile picture seemed broken.

![image](https://github.com/aaronpk/live-chat-overlay/assets/42357900/c9c7cb0c-3bc8-43cd-acee-b1a87f103885)


It replaces all `32` with `128` of the author image src URL, and even with a small chance it will cause some profile picture identifiers to change, eventually breaking the image.

As an example here's my YouTube profile picture link:
https://yt4.ggpht.com/-faUriaNHdyz9kBw2sS7fkeFUFOKrCgzl8HwOD0f6nqLG2PC1maT32X-c8O5h13EWHThhUAd9g=s64-c-k-c0x00ffffff-no-rj

It has a `32` in the identifier, so excluding the identifier by simply replacing the `32` after the first `=` sign that defines a parameter will solve the problem.

I implemented this logic by splitting the URL into 2 parts, before and after the `=` sign. Also, as you can see in the example above, some profile pictures have a size of `64`, so I also replaced `64` with `128`.

And fixed a small typo.