### PR TITLE
Add pointer-events to highlight-chat (fix Chrome on linux) 

### DIFF
--- a/youtube.css
+++ b/youtube.css
@@ -118,6 +118,7 @@ highlight-chat {
     color: #fff;
     font-size: 30px;
     transform: scale(var(--comment-scale));
+    pointer-events: none !important;
 }
 highlight-chat.preview {
     border: 1px #ccc solid;


### PR DESCRIPTION
The highlight-chat class prevents anything being click on Google Chrome (Linux).
This adds pointer-events to fix the issue